### PR TITLE
chore: add vue-demi as dep, close #1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vite-vue2-example",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -13,6 +14,7 @@
         "core-js": "3.9.0",
         "typescript": "4.2.2",
         "vue": "2.6.12",
+        "vue-demi": "^0.7.0",
         "vue-router": "3.5.1"
       },
       "devDependencies": {
@@ -4785,9 +4787,9 @@
       "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
     },
     "node_modules/vue-demi": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.6.0.tgz",
-      "integrity": "sha512-8GEJa0mHJpYJeGeq5fD1pJct2kfdl30PHfmL1NaJ97mgKPyKojlIRt/3inGBK4Y0ylCI6T5vOo3chwpqDOq/Hw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.7.0.tgz",
+      "integrity": "sha512-yOQ/BMfvTFbguwxQ1h6USEFkxvOI8ThhyZ1+57vlOl4jBZKC6ThmkzuQv4KOv4ItdxTj/foZBR6Lr5+tcr7nqg==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -4797,7 +4799,13 @@
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-beta.1",
         "vue": "^2.6.0 || >=3.0.0-rc.1"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue-eslint-parser": {
@@ -8739,9 +8747,9 @@
       "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
     },
     "vue-demi": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.6.0.tgz",
-      "integrity": "sha512-8GEJa0mHJpYJeGeq5fD1pJct2kfdl30PHfmL1NaJ97mgKPyKojlIRt/3inGBK4Y0ylCI6T5vOo3chwpqDOq/Hw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.7.0.tgz",
+      "integrity": "sha512-yOQ/BMfvTFbguwxQ1h6USEFkxvOI8ThhyZ1+57vlOl4jBZKC6ThmkzuQv4KOv4ItdxTj/foZBR6Lr5+tcr7nqg==",
       "requires": {}
     },
     "vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "core-js": "3.9.0",
     "typescript": "4.2.2",
     "vue": "2.6.12",
+    "vue-demi": "^0.7.0",
     "vue-router": "3.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Although npm will hoist nested dependencies, it's still better to explictly define your direct deps.